### PR TITLE
Update sha256 constructor 3.2.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ source:
     folder: constructor  # [win]
 
 build:
-  number: 1
+  number: 2
   ignore_run_exports:
     - '*'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
       - conda_patches/0002-Manipulate-PATH-directly-instead-of-_call_ing-conda.patch
 
   - url: https://github.com/conda/constructor/archive/{{ constructor_version }}.tar.gz  # [win]
-    sha256: 667bc5e0c358b2bff532d8ad9559bda31f9e0cf1fabe1798e3b4f7381ea62a8e  # [win]
+    sha256: 57497a316a26631bb56c354a727980889015a1a79bf1a51131695ddbc51a0ca5  # [win]
     folder: constructor  # [win]
 
 build:


### PR DESCRIPTION
The sha256 of constructor 3.2.2 changed which made the merge commit of https://github.com/conda-forge/conda-standalone-feedstock/pull/24 failed on windows: https://github.com/conda-forge/conda-standalone-feedstock/runs/4840653115.

I don't think we need to bump the build number in this case, because other packages are the same and we only need to g.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
